### PR TITLE
Add transfer money endpoint that use only target userId

### DIFF
--- a/server/endpoints.js
+++ b/server/endpoints.js
@@ -109,6 +109,23 @@ function setupEndpoints (server) {
     })
   })
 
+  const transferByUserIdSchema = Joi.object().keys({
+    fromAccountId: Joi.string().min(1).required(),
+    toUserId: Joi.string().min(1).required(),
+    amount: Joi.string().min(1).required(),
+    currency: Joi.string().min(3).max(3).trim().uppercase().required()
+  })
+  server.route({
+    method: 'POST',
+    path: '/api/transferByUserId',
+    handler: createHandler((request, reply) => {
+      const valid = validate(request.payload, transferByUserIdSchema)
+      const actorId = request.auth.credentials.id
+      return AccountService.transferByUserId(valid, actorId)
+      .then((transactionHistory) => reply({ transactionHistory }))
+    })
+  })
+
   server.route({
     method: 'GET',
     path: '/api/history/{accountId}',

--- a/server/models/account.js
+++ b/server/models/account.js
@@ -8,6 +8,7 @@ const T = require('tcomb')
 
 const validate = require('./validate')
 
+const TYPE_MAIN = 11
 const TYPE_NORMAL = 1
 const TYPE_INTERNAL = 10
 const ACCOUNT_WORLD = '100'
@@ -56,6 +57,10 @@ function create (account) {
 
 function getByUserId (userId) {
   return Db.query('SELECT * FROM account WHERE userId = ? ORDER BY id ASC', [userId])
+}
+
+function getMainAccountByUserId(userId) {
+  return Db.findOne('SELECT * FROM account WHERE userId = ? AND type = 11', [userId])
 }
 
 function getTransactionHistory (accountId, max) {
@@ -198,11 +203,49 @@ function _transfer (conn, opts) {
   })
 }
 
+function _transferByUserId (conn, opts) {
+  return P.try(() => {
+    return conn.queryAsync(
+      'SELECT * FROM account WHERE id = ? FOR UPDATE',
+      [opts.fromAccountId]
+    )
+    .then((fromAccount) => {
+      if (!fromAccount.length) {
+        throw Boom.notFound(`Could not find source account id ${opts.fromAccountId} currency ${opts.currency}`)
+      }
+      return conn.queryAsync(
+        'SELECT * FROM account WHERE userId = ? AND type = 11 FOR UPDATE',
+        [opts.toUserId]
+      )
+      .then((toUserId) => {
+        if (!toUserId.length) {
+          throw Boom.notFound(`Could not find target user id ${opts.toUserId}`)
+        }
+
+        return _debitCredit(conn, {
+          fromAccountId: fromAccount[0].id,
+          toAccountId: toUserId[0].id,
+          amount: opts.amount,
+          transactionType: opts.transactionType
+        })
+      })
+      .then((transactionHistoryId) => (
+        conn.commitAsync()
+        .then(() => transactionHistoryId)
+      ))
+    })
+  })
+}
+
 function transfer (opts) {
   return Db.transaction((conn) => _transfer(conn, opts))
 }
 
+function transferByUserId(opts) {
+  return Db.transaction((conn) => _transferByUserId(conn, opts))
+}
 module.exports = {
+  TYPE_MAIN,
   TYPE_NORMAL,
   TYPE_INTERNAL,
   ACCOUNT_WORLD,
@@ -223,6 +266,7 @@ module.exports = {
   getTransactionHistory,
   getTransactionHistoryById,
   getTransactionHistoryForAccountOwner,
-
+  getMainAccountByUserId,
+  transferByUserId,
   transfer
 }

--- a/server/services/starter.js
+++ b/server/services/starter.js
@@ -6,6 +6,7 @@ const T = require('tcomb')
 const User = require('../models/user')
 
 const AccountService = require('./account')
+const Account = require('../models/account')
 const UserService = require('./user')
 
 const getStarter = P.coroutine(function * (userId, defaultCurrency) {
@@ -22,7 +23,8 @@ const getStarter = P.coroutine(function * (userId, defaultCurrency) {
   // using the default currency.
   if (!accounts.length) {
     const account = yield AccountService.create({
-      currency: defaultCurrency
+      currency: defaultCurrency,
+      type: Account.TYPE_MAIN
     }, userId)
     accounts = [account]
   }


### PR DESCRIPTION
- 1st time that user create user's account and call starter api. It will create money account type = 11 that's a main account of the user.
- For transfer money. It will send the money directly to the main account of target user.
